### PR TITLE
Use win-spawn to fix postinstall issue on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,17 @@
   },
   "homepage": "https://github.com/doctyper/customizr",
   "dependencies": {
-    "modernizr": "https://github.com/Modernizr/Modernizr/tarball/master",
-    "deep-equal": "~0.1.2",
     "colors": "~0.6.2",
-    "grunt-legacy-log": "~0.1.1",
-    "underscore": "~1.5.2",
-    "mkdirp": "~0.3.5",
-    "promised-io": "~0.3.4",
-    "optimist": "~0.6.0",
+    "deep-equal": "~0.1.2",
     "glob": "~3.2.8",
-    "nopt": "~2.1.2"
+    "grunt-legacy-log": "~0.1.1",
+    "mkdirp": "~0.3.5",
+    "modernizr": "https://github.com/Modernizr/Modernizr/tarball/master",
+    "nopt": "~2.1.2",
+    "optimist": "~0.6.0",
+    "promised-io": "~0.3.4",
+    "underscore": "~1.5.2",
+    "win-spawn": "^2.0.0"
   },
   "devDependencies": {
     "expect.js": "~0.2.0",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,8 +1,8 @@
 var colors = require("colors");
 var path = require("path");
-var cwd  = path.resolve(__dirname, "..");
-var cp   = require("child_process");
-var fs   = require("fs");
+var cwd = path.resolve(__dirname, "..");
+var spawn = require('win-spawn');;
+var fs = require("fs");
 
 var modernizrPath = path.join(cwd, "node_modules", "modernizr");
 
@@ -14,7 +14,7 @@ if (fs.existsSync(modernizrPath)) {
 	console.log("--------------------------------------------------------------------------------------------------------------------------------------------");
 	console.log();
 
-	var child = cp.spawn("npm", ["install", "--production"], {
+	var child = spawn("npm", ["install", "--production"], {
 		cwd: modernizrPath,
 		stdio: "inherit"
 	});


### PR DESCRIPTION
Mentioned in https://github.com/doctyper/gulp-modernizr/issues/14#issuecomment-56601049
Same issue as https://github.com/Modernizr/Modernizr/pull/1290

Sorry for the changes to package.json (apart from adding "win-spawn"), recent npm versions seem to reorder the dependencies alphabetically.
