### PR TITLE
Update default config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ A sample config file is below. Default values shown:
 
 	// Based on default settings on http://modernizr.com/download/
 	"options" : [
-		"setClasses",
 		"addTest",
 		"html5printshiv",
 		"testProp",


### PR DESCRIPTION
I was wondering why Modernizr classes weren't adding until I dig into the commit history. The `README.md` is misleading so I update it.

Anyway, what is the reason behind disabling `setClasses` by default?
