### PR TITLE
Adding classPrefix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ A sample config file is below. Default values shown:
 	},
 
 	// Have custom Modernizr tests? Add them here.
-	"customTests" : []
+	"customTests" : [],
+	
+	// Add custom prefix to Modernizr CSS classes
+	"classPrefix" : '' 
 }
 ```
 
@@ -148,6 +151,11 @@ This is an optional parameter.
 
 ###### **`customTests`** (Array, optional)
 Have custom Modernizr tests? Add paths to their location here. The object supports all [minimatch](https://github.com/isaacs/minimatch) options.
+
+This is an optional parameter.
+
+###### **`classPrefix`** (String, optional)
+Add custom prefix to Modernizr classes to avoid clashes with your preexisting class names.
 
 This is an optional parameter.
 


### PR DESCRIPTION
The existing PR https://github.com/doctyper/customizr/pull/25 is incorrect, in https://github.com/doctyper/customizr/pull/16 the config variable was  `classPrefix`.

After spending some time searching for this variable, merging this would help people greatly.
