### PR TITLE
Update glob to 7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "colors": "~0.6.2",
     "deep-equal": "~0.1.2",
-    "glob": "~3.2.8",
+    "glob": "~7.0.6",
     "grunt-legacy-log": "~0.1.1",
     "mkdirp": "~0.3.5",
     "modernizr": "^3.0.0-alpha",


### PR DESCRIPTION
By updating glob we are also updating minimatch to 3.0.2+ which
resolves the following issue https://nodesecurity.io/advisories/118
