### PR TITLE
Fix arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/Modernizr/customizr",
   "dependencies": {
-    "colors": "~1.2.5",
+    "colors": "~1.3.0",
     "cross-spawn": "~6.0.5",
     "fast-deep-equal": "~2.0.1",
     "glob": "~7.1.2",
@@ -35,12 +35,12 @@
     "nopt": "~4.0.1",
     "optimist": "~0.6.1",
     "promised-io": "~0.3.5",
-    "underscore": "~1.9.0"
+    "underscore": "~1.9.1"
   },
   "devDependencies": {
     "expect.js": "~0.3.1",
     "fs-extra": "~6.0.1",
-    "mocha": "~5.1.1",
+    "mocha": "~5.2.0",
     "nexpect": "~0.5.0"
   }
 }

--- a/src/builder.js
+++ b/src/builder.js
@@ -5,16 +5,8 @@ module.exports = function (modernizrPath) {
 	var argv = require("optimist").argv;
 
 	// Config object
-	var _quiet = argv.quiet,
-		_force = argv.force,
+	var _force = argv.force,
 		_verbose = argv.verbose;
-
-	// Dependencies
-	var cp = require("child_process"),
-		fs = require("fs"),
-		path = require("path"),
-		colors = require("colors"),
-		cwd = process.cwd();
 
 	// Deferreds
 	var promise = require("promised-io/promise");

--- a/src/builder.js
+++ b/src/builder.js
@@ -5,8 +5,7 @@ module.exports = function (modernizrPath) {
 	var argv = require("optimist").argv;
 
 	// Config object
-	var _force = argv.force,
-		_verbose = argv.verbose;
+	var _force = argv.force;
 
 	// Deferreds
 	var promise = require("promised-io/promise");
@@ -83,11 +82,9 @@ module.exports = function (modernizrPath) {
 			utils.log.writeln();
 			utils.log.write("Building your customized Modernizr".bold.white);
 
-			if (!_verbose) {
-				_interval = setInterval(function () {
-					utils.log.write(".".grey);
-				}.bind(this), 200);
-			}
+			_interval = setInterval(function () {
+				utils.log.write(".".grey);
+			}.bind(this), 200);
 
 			var modernizr = require("modernizr");
 

--- a/src/builder.js
+++ b/src/builder.js
@@ -11,7 +11,7 @@ module.exports = function (modernizrPath) {
 	var promise = require("promised-io/promise");
 
 	// Cache utils
-	var utils;
+    var utils;
 
 	return {
 		writeCodeToFile : function (result, config) {
@@ -51,13 +51,16 @@ module.exports = function (modernizrPath) {
 			}
 
 			if (useCachedVersion) {
-				utils.log.writeln();
 
-				utils.log.writeln("No config or test changes detected".bold.white);
-				utils.log.ok("The build step has been bypassed. Use `--force` to override.".grey);
+				if(!settings.quiet) {
+                    utils.log.writeln();
 
-				if (settings.dest) {
-					utils.log.ok(("Your current file can be found in " + settings.dest).grey);
+                    utils.log.writeln("No config or test changes detected".bold.white);
+                    utils.log.ok("The build step has been bypassed. Use `--force` to override.".grey);
+
+                    if (settings.dest) {
+                        utils.log.ok(("Your current file can be found in " + settings.dest).grey);
+                    }
 				}
 
 				setTimeout(function () {
@@ -71,28 +74,33 @@ module.exports = function (modernizrPath) {
 			}
 
 			// Echo settings
-			utils.log.writeln();
-			utils.log.ok("Ready to build using these settings:");
-			utils.log.ok(options.join(", ").grey);
+            if(!settings.quiet) {
+                utils.log.writeln();
+                utils.log.ok("Ready to build using these settings:");
+                utils.log.ok(options.join(", ").grey);
 
-			if (minify) {
-				utils.log.ok("Your file will be minified with UglifyJS".grey);
-			}
+                if (minify) {
+                    utils.log.ok("Your file will be minified with UglifyJS".grey);
+                }
 
-			utils.log.writeln();
-			utils.log.write("Building your customized Modernizr".bold.white);
+                utils.log.writeln();
+                utils.log.write("Building your customized Modernizr".bold.white);
 
-			_interval = setInterval(function () {
-				utils.log.write(".".grey);
-			}.bind(this), 200);
+                _interval = setInterval(function () {
+                    utils.log.write(".".grey);
+                }.bind(this), 200);
+            }
 
 			var modernizr = require("modernizr");
 
 			modernizr.build(modernizrOptions, function (result) {
-				utils.log.write("...".grey);
-				utils.log.ok();
 
-				clearInterval(_interval);
+                if(!settings.quiet) {
+                    utils.log.write("...".grey);
+                    utils.log.ok();
+
+                    clearInterval(_interval);
+                }
 
 				// Write code to file
 				if (settings.dest) {

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -5,12 +5,10 @@ module.exports = function (modernizrPath) {
 	var argv = require("optimist").argv;
 
 	// Config object
-	var _quiet = argv.quiet,
-		_verbose = argv.verbose;
+	var _quiet = argv.quiet;
 
 	// Dependencies
-	var cp = require("child_process"),
-		fs = require("fs"),
+	var fs = require("fs"),
 		cwd = process.cwd(),
 		path = require("path");
 

--- a/src/crawler.js
+++ b/src/crawler.js
@@ -2,11 +2,6 @@
 module.exports = function (modernizrPath) {
 	"use strict";
 
-	var argv = require("optimist").argv;
-
-	// Config object
-	var _quiet = argv.quiet;
-
 	// Dependencies
 	var fs = require("fs"),
 		cwd = process.cwd(),
@@ -105,7 +100,7 @@ module.exports = function (modernizrPath) {
 
 			var matchedTests = this.matchedTestsInFile[file];
 
-			if (!_quiet && matchedTests && matchedTests.length) {
+			if (!settings.quiet && matchedTests && matchedTests.length) {
 				utils.log.writeln();
 
 				var testCount = matchedTests.length;
@@ -174,7 +169,7 @@ module.exports = function (modernizrPath) {
 				return test.path;
 			});
 
-			if (!_quiet && tests && tests.length) {
+			if (!settings.quiet && tests && tests.length) {
 				utils.log.writeln();
 				utils.log.ok("Explicitly including these tests:");
 				utils.log.ok(tests.map(function (test) {
@@ -192,7 +187,7 @@ module.exports = function (modernizrPath) {
 				return test.path;
 			});
 
-			if (!_quiet && excludedTests && excludedTests.length) {
+			if (!settings.quiet && excludedTests && excludedTests.length) {
 				utils.log.writeln();
 				utils.log.ok("Explicitly excluding these tests:");
 				utils.log.ok(excludedTests.map(function (test) {
@@ -219,7 +214,7 @@ module.exports = function (modernizrPath) {
 			if (settings.crawl !== true && settings.useBuffers !== true) {
 				tests = this.crawler.filterTests(tests);
 
-				if (!_quiet) {
+				if (!settings.quiet) {
 					utils.log.subhead("Skipping file traversal");
 				}
 
@@ -230,7 +225,7 @@ module.exports = function (modernizrPath) {
 				return deferred.promise;
 			}
 
-			if (!_quiet) {
+			if (!settings.quiet) {
 				utils.log.subhead("Looking for Modernizr references");
 			}
 

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -2,11 +2,6 @@
 module.exports = function (modernizrPath) {
 	"use strict";
 
-	// Dependencies
-	var cp = require("child_process"),
-		fs = require("fs"),
-		path = require("path");
-
 	// Deferreds
 	var promise = require("promised-io/promise");
 

--- a/src/settings.json
+++ b/src/settings.json
@@ -9,6 +9,7 @@
 			"testProp",
 			"fnBind"
 		],
+        "quiet": false,
 		"uglify" : true,
 		"tests" : [],
 		"excludeTests": [],

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,6 @@ module.exports = function (modernizrPath) {
 		path = require("path"),
 		glob = require("glob"),
 		equal = require("fast-deep-equal"),
-		colors = require("colors"),
 		mkdirp = require("mkdirp"),
 		_ = require("underscore");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,8 @@ module.exports = function (modernizrPath) {
 	var fs = require("fs"),
 		path = require("path"),
 		glob = require("glob"),
-		equal = require("fast-deep-equal"),
+        colors = require("colors"),
+        equal = require("fast-deep-equal"),
 		mkdirp = require("mkdirp"),
 		_ = require("underscore");
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,8 +35,7 @@ describe("customizr", function () {
 		nexpect.spawn(cli, [
 			"--config", settings.custom
 		], {
-			stripColors: true,
-			verbose: true
+			stripColors: true
 		})
 		.wait("Looking for Modernizr references")
 
@@ -69,8 +68,7 @@ describe("customizr", function () {
 		nexpect.spawn(cli, [
 			"--config", settings.custom
 		], {
-			stripColors: true,
-			verbose: true
+			stripColors: true
 		})
 		.wait("Looking for Modernizr references")
 
@@ -103,8 +101,7 @@ describe("customizr", function () {
 			"--config", settings.custom,
 			"--force"
 		], {
-			stripColors: true,
-			verbose: true
+			stripColors: true
 		})
 		.wait("Looking for Modernizr references")
 
@@ -137,8 +134,7 @@ describe("customizr", function () {
 		nexpect.spawn(cli, [
 			"--config", settings.cache
 		], {
-			stripColors: true,
-			verbose: true
+			stripColors: true
 		})
 		.wait("Looking for Modernizr references")
 
@@ -187,8 +183,7 @@ describe("custom builds", function () {
 			nexpect.spawn(cli, [
 				"--config", settings.select
 			], {
-				stripColors: true,
-				verbose: true
+				stripColors: true
 			})
 
 			.wait(">> Explicitly including these tests:")
@@ -256,8 +251,7 @@ describe("custom builds", function () {
 			nexpect.spawn(cli, [
 				"--config", settings.exclude
 			], {
-				stripColors: true,
-				verbose: true
+				stripColors: true
 			})
 
 			.wait(">> Explicitly excluding these tests:")
@@ -307,8 +301,7 @@ describe("custom builds", function () {
 			nexpect.spawn(cli, [
 				"--config", settings.prefixed
 			], {
-				stripColors: true,
-				verbose: true
+				stripColors: true
 			})
 
 			.wait("Looking for Modernizr references")


### PR DESCRIPTION
There were arguments like "verbose" and "quiet", but they were poorly implemented or not at all. This unifies them under the option "quiet". Defaults to false and behaves like the status quo.

If set to true, no log is written at all when geenrating a modernizr build. Requested by gulp-modernizr userhttps://github.com/rejas/gulp-modernizr/issues/25